### PR TITLE
Update s3

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -13,7 +13,7 @@ resource "aws_lb" "example" {
   load_balancer_type         = "application"
   internal                   = false
   idle_timeout               = 60
-  enable_deletion_protection = true
+  enable_deletion_protection = false
 
   // Specify public subnets in network.tf.
   subnets = [

--- a/s3.tf
+++ b/s3.tf
@@ -60,7 +60,8 @@ S3 log bucket
 */
 
 resource "aws_s3_bucket" "alb_log" {
-  bucket = "hoda-practice-terraform-alb-log"
+  bucket        = "hoda-practice-terraform-alb-log"
+  force_destroy = true
 
   // lifecycle_rule is an option to define lifecycle rule.
   // Here, files that are 180 days old will be automatically deleted.
@@ -85,10 +86,11 @@ data "aws_iam_policy_document" "alb_log" {
     actions   = ["s3:PutObject"]
     resources = ["arn:aws:s3:::${aws_s3_bucket.alb_log.id}/*"]
 
-    // The identifiers is the account ID.
+    // The identifiers is the account ID. This is not your AWS account ID.
+    // https://docs.aws.amazon.com/ja_jp/elasticloadbalancing/latest/classic/enable-access-logs.html
     principals {
       type        = "AWS"
-      identifiers = ["xxxxyyyyzzzz"]
+      identifiers = ["582318560864"]
     }
   }
 }


### PR DESCRIPTION
Repair the below error.

```
Error: Failure configuring LB attributes: InvalidConfigurationRequest: Access Denied for bucket: hoda-practice-terraform-alb-log. Please check S3bucket permission
	status code: 400, request id: b5a93fcd-a022-4e82-9fc1-a43367962638
  on alb.tf line 8, in resource "aws_lb" "example":
   8: resource "aws_lb" "example" {
```